### PR TITLE
Update k8s-setup.md

### DIFF
--- a/Kubernetes/k8s-setup.md
+++ b/Kubernetes/k8s-setup.md
@@ -75,7 +75,8 @@
     kubectl expose deployment sample-nginx --port=80 --type=LoadBalancer
     kubectl get services -o wide
     ```
- 1. To delete cluster
+ 1. To delete cluster: In order to delete the cluster, you must set KOPS_STATE_STORE environment variable if it is set temporary or else kops command cannot identify cluster details. 
     ```sh
+     export KOPS_STATE_STORE=s3://dev.k8s.valaxy.in   //set environment variable 
      kops delete cluster dev.k8s.valaxy.in --yes
     ```


### PR DESCRIPTION
If you simply execute  kops delete cluster dev.k8s.valaxy.in --yes it is throwing error, as KOPS_STATE_STORE is set temporary you must set it again to get cluster details and perform delete operation